### PR TITLE
Fix: apparently name can be "null"

### DIFF
--- a/src/Models/ISOs/ISO.php
+++ b/src/Models/ISOs/ISO.php
@@ -36,7 +36,7 @@ class ISO extends Model implements Resource
      * @param string $description
      * @param string $type
      */
-    public function __construct(int $id, string $name, string $description = null, string $type = null)
+    public function __construct(int $id, string $name = null, string $description = null, string $type = null)
     {
         $this->id = $id;
         $this->name = $name;


### PR DESCRIPTION
Hetzner support added an ISO for me, but I can't pull it up using your code because the name is "null". Not sure if this is a "bug" in your code, or if it's how they added my ISO in and a bug on their end. But adding `= null` fixes it. ;-)